### PR TITLE
Tuning GitHub workflow triggers for CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,9 @@ name: CD
 
 on:
   push:
+    branches:
+      - main
+      - "release/*"
     tags:
       - '*'
 


### PR DESCRIPTION
- depoy to Maven Central Repository on push to main or "release/*" branches