### PR TITLE
Tuning GitHub workflow triggers for CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,11 +2,8 @@ name: CD
 
 on:
   push:
-    branches:
-      - main
-      - 'release/*'
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   deploy:


### PR DESCRIPTION
- deploy to Maven Central Repository on push version tags only