### PR TITLE
Bump org.apache.logging.log4j:log4j-core from 2.22.0 to 2.23.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 dependencies {
     implementation 'com.sendgrid:sendgrid-java:4.10.1'
     implementation 'jakarta.mail:jakarta.mail-api:2.1.2'
-    implementation 'org.apache.logging.log4j:log4j-core:2.22.0'
-    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.22.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.23.0'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.23.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'com.lmax:disruptor:4.0.0' // required for log4j2 AsyncLogger
     testImplementation 'com.sun.mail:javax.mail:1.6.2' // required for log4j2 SMTPAppender


### PR DESCRIPTION
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.23.0