### PR TITLE
build: upgrade to JDK 25 and maintain JRE 11 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 17
-          - 21
           - 25
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 25
           cache: 'gradle'
       - name: Build with Gradle
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,12 @@ tasks.withType<JavaCompile>().configureEach {
         options.release.set(25)
     } else {
         options.release.set(11)
+        options.compilerArgs.addAll(
+            listOf(
+                "-Alog4j.graalvm.groupId=${project.group}",
+                "-Alog4j.graalvm.artifactId=${project.name}"
+            )
+        )
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,10 +12,8 @@ group = "com.github.akunzai"
 version = "3.2.0"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     withJavadocJar()
     withSourcesJar()
@@ -144,8 +142,9 @@ spotbugs {
 
 tasks.withType<JavaCompile>().configureEach {
     if (name.contains("Test")) {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
+        options.release.set(25)
+    } else {
+        options.release.set(11)
     }
 }
 

--- a/src/main/java/com/github/akunzai/log4j/SendGridManager.java
+++ b/src/main/java/com/github/akunzai/log4j/SendGridManager.java
@@ -14,11 +14,8 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractManager;
 import org.apache.logging.log4j.core.appender.ManagerFactory;
-import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.impl.MutableLogEvent;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.util.CyclicBuffer;
-import org.apache.logging.log4j.message.ReusableMessage;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,12 +51,7 @@ class SendGridManager extends AbstractManager {
     }
 
     public void add(LogEvent event) {
-        if (event instanceof Log4jLogEvent && event.getMessage() instanceof ReusableMessage) {
-            ((Log4jLogEvent) event).makeMessageImmutable();
-        } else if (event instanceof MutableLogEvent) {
-            event = ((MutableLogEvent) event).createMemento();
-        }
-        buffer.add(event);
+        buffer.add(event.toImmutable());
     }
 
     /**


### PR DESCRIPTION
This PR upgrades the project to JDK 25 toolchain and fixes several build-time warnings.

Major changes:
- **JDK Upgrade**: Switched to JDK 25 toolchain via Gradle Toolchains.
- **JRE 11 Compatibility**: Maintained JRE 11 compatibility for the main library using the `options.release = 11` flag.
- **CI/CD Updates**: Updated GitHub Workflows build matrix to reflect the upgrade (now testing JDK 25).
- **Warning Fixes**:
  - Configured Log4j GraalVM annotation processor options to remove naming warnings and correctly generate metadata.
  - Replaced deprecated `MutableLogEvent.createMemento()` with the recommended `LogEvent.toImmutable()` in `SendGridManager.java`.
  - Cleaned up unused imports related to deprecated internal API handling.

Verified with `./gradlew clean build` - the build is now completely free of warnings.