### PR TITLE
upgrade log4j dependency to 2.26.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 spotbugs = "6.5.1"
 sendgrid = "4.10.3"
 jakartaMail = "2.1.5"
-log4j = "2.25.4"
+log4j = "2.26.0"
 junit = "6.0.3"
 disruptor = "4.0.0"
 javaxMail = "1.6.2"


### PR DESCRIPTION
- https://github.com/apache/logging-log4j2/releases/tag/rel/2.26.0