### PR TITLE
upgrade jackson-databind to 2.22.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ disruptor = "4.0.0"
 javaxMail = "1.6.2"
 spotbugsPlugin = "4.9.8"
 findsecbugs = "1.14.0"
-jackson = "2.21.3"
+jackson = "2.22.0"
 commonsCodec = "1.22.0"
 jreleaser = "1.24.0"
 


### PR DESCRIPTION
Upgrades the `jackson-databind` constraint from 2.21.3 to 2.22.0 (latest stable 2.x release, released 2026-06-02).

Dependency resolution verified locally — all jackson artifacts (core, annotations, databind) resolve correctly from Maven Central.